### PR TITLE
Add support for platforms lacking a working sem_open implementation

### DIFF
--- a/ytcc/core.py
+++ b/ytcc/core.py
@@ -173,8 +173,11 @@ class Ytcc:
 
         channels = map(lambda channel: channel.yt_channelid, self.db.get_channels())
 
-        with Pool(unpack_optional(os.cpu_count(), lambda: 1) * 2) as pool:
-            videos = chain.from_iterable(pool.map(self._update_channel, channels))
+        try:
+            with Pool(unpack_optional(os.cpu_count(), lambda: 1) * 2) as pool:
+                videos = chain.from_iterable(pool.map(self._update_channel, channels))
+        except ImportError:
+            videos = chain.from_iterable(map(self._update_channel, channels))
 
         self.db.add_videos(videos)
 


### PR DESCRIPTION
The `Pool()` call throws this error on [Termux](https://termux.com/):

```
ImportError: This platform lacks a functioning sem_open implementation, therefore, the required synchronization primitives needed will not function, see issue 3770.
```

This commit provides a fail-safe in case that happens.