### PR TITLE
 Changed string formatting to use Python 3's str.format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,5 +93,9 @@ ENV/
 # Pycharm project settings
 .idea/
 
+# Pydev project settings
+.pydevproject
+.project
+
 # mypy cache
 .mypy_cache/

--- a/ytcc/arguments.py
+++ b/ytcc/arguments.py
@@ -27,7 +27,7 @@ from gettext import gettext as _
 
 def is_directory(string: str) -> str:
     if not os.path.isdir(string):
-        msg = _("%r is not a directory") % string
+        msg = _("{!r} is not a directory").format(string)
         raise argparse.ArgumentTypeError(msg)
 
     return string
@@ -37,7 +37,7 @@ def is_date(string: str) -> datetime.datetime:
     try:
         return date_parser.parse(string)
     except ValueError:
-        msg = _("%r is not a valid date") % string
+        msg = _("{!r} is not a valid date").format(string)
         raise argparse.ArgumentTypeError(msg)
 
 
@@ -137,10 +137,8 @@ def get_args() -> argparse.Namespace:
 
     parser.add_argument("-o", "--columns",
                         help=_("specifies which columns will be printed when listing videos. COL "
-                               "can be any of %(columns)s. All columns can be enabled with "
-                               "'all'") % {
-                                 "columns": str(ytcc.cli.table_header)
-                             },
+                               "can be any of {columns}. All columns can be enabled with "
+                               "'all'").format(columns=str(ytcc.cli.table_header)),
                         nargs='+',
                         metavar="COL",
                         choices=["all", *ytcc.cli.table_header])

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -116,10 +116,8 @@ def interactive_prompt(video: Video) -> bool:
 
     while not executed_cmd:
         try:
-            question = _('Play video "%(title)s" by "%(channel)s"?') % {
-                "title": video.title,
-                "channel": video.channelname
-            }
+            question = (_('Play video "{video.title}" by "{video.channelname}"?')
+                        .format(video=video))
             choice = input(question +
                            '\n[y(es)/n(o)/a(udio)/m(ark)/q(uit)/h(elp)] (Default: y) > ')
         except EOFError:
@@ -142,9 +140,8 @@ def interactive_prompt(video: Video) -> bool:
 
         if invalid_cmd:
             print()
-            print(_("'%(cmd)s' is an invalid command. Type 'help' for more info.\n") % {
-                "cmd": choice
-            })
+            print(_("'{cmd}' is an invalid command. Type 'help' for more info.\n")
+                  .format(cmd=choice))
             executed_cmd = False
 
     return True
@@ -232,10 +229,8 @@ def match_quickselect(tags: List[str], alphabet: Set[str]) -> str:
 
 def watch(video_ids: Optional[Iterable[int]] = None) -> None:
     def print_title(video: Video) -> None:
-        print(_('Playing "%(video)s" by "%(channel)s"...') % {
-            "video": video.title,
-            "channel": video.channelname
-        })
+        print(_('Playing "{video.title}" by "{video.channelname}"...')
+              .format(video=video))
 
     if not video_ids:
         videos = ytcc_core.list_videos()
@@ -357,11 +352,11 @@ def add_channel(name: str, channel_url: str) -> None:
     try:
         ytcc_core.add_channel(name, channel_url)
     except core.BadURLException:
-        print(_("'%r' is not a valid YouTube URL") % channel_url)
+        print(_("'{!r}' is not a valid YouTube URL").format(channel_url))
     except core.DuplicateChannelException:
-        print(_("You are already subscribed to '%r'") % name)
+        print(_("You are already subscribed to '{!r}'").format(name))
     except core.ChannelDoesNotExistException:
-        print(_("The channel '%r' does not exist") % channel_url)
+        print(_("The channel '{!r}' does not exist").format(channel_url))
 
 
 def cleanup() -> None:


### PR DESCRIPTION
The only instance of using the old %-style formatting that remains is in `config.py` in the `DEFAULTS` dictionary. This is because it is used to configure `youtube-dl`, which still uses %-style formatting for file names.

```python
DEFAULTS: Dict[str, Dict[str, Any]] = {
    "YTCC": {
        ...
    },
    "youtube-dl": {
        "format": "bestvideo[height<=?1080]+bestaudio/best",
        "outputTemplate": "%(title)s.%(ext)s",
        ...
    },
    ...
}
```