### PR TITLE
Add date-sorting to watch() when no IDs are given

### DIFF
--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -233,6 +233,7 @@ def watch(video_ids: Optional[Iterable[int]] = None) -> None:
 
     if not video_ids:
         videos = ytcc_core.list_videos()
+        sorted(videos, key=lambda v: v.publish_date)
     else:
         videos = ytcc_core.get_videos(video_ids)
 


### PR DESCRIPTION
When no video IDs are selected, videos are sorted by date, rather than ID.