### PR TITLE
Add date-sorting to watch() when no IDs are given

### DIFF
--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -233,6 +233,7 @@ def watch(video_ids: Optional[Iterable[int]] = None) -> None:
 
     if not video_ids:
         videos = ytcc_core.list_videos()
+        videos = sorted(videos, key=lambda v: v.publish_date)
     else:
         videos = ytcc_core.get_videos(video_ids)
 
@@ -331,6 +332,7 @@ def mark_watched(video_ids: Optional[List[int]]) -> None:
 
 def list_videos() -> None:
     videos = ytcc_core.list_videos()
+    videos = sorted(videos, key=lambda v: v.publish_date)
     if not videos:
         print(_("No videos to list. No videos match the given criteria."))
     else:

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -233,7 +233,6 @@ def watch(video_ids: Optional[Iterable[int]] = None) -> None:
 
     if not video_ids:
         videos = ytcc_core.list_videos()
-        videos = sorted(videos, key=lambda v: v.publish_date)
     else:
         videos = ytcc_core.get_videos(video_ids)
 
@@ -332,7 +331,6 @@ def mark_watched(video_ids: Optional[List[int]]) -> None:
 
 def list_videos() -> None:
     videos = ytcc_core.list_videos()
-    videos = sorted(videos, key=lambda v: v.publish_date)
     if not videos:
         print(_("No videos to list. No videos match the given criteria."))
     else:

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -230,12 +230,16 @@ def match_quickselect(tags: List[str], alphabet: Set[str]) -> str:
 def watch(video_ids: Optional[Iterable[int]] = None) -> None:
     def print_title(video: Video) -> None:
         print(_('Playing "{video.title}" by "{video.channelname}"...').format(video=video))
-
-    if not video_ids:
-        videos = ytcc_core.list_videos()
-    else:
-        videos = ytcc_core.get_videos(video_ids)
-
+        
+    videos = list()
+    try:
+        if not video_ids:
+            videos = ytcc_core.list_videos()
+        else:
+            videos = ytcc_core.get_videos(video_ids)
+    except core.BadConfigException as e:
+        print(e)
+    
     quickselect = ytcc_core.config.quickselect
 
     if not videos:
@@ -330,7 +334,11 @@ def mark_watched(video_ids: Optional[List[int]]) -> None:
 
 
 def list_videos() -> None:
-    videos = ytcc_core.list_videos()
+    videos = list()
+    try:
+        videos = ytcc_core.list_videos()
+    except core.BadConfigException as e:
+        print(e)
     if not videos:
         print(_("No videos to list. No videos match the given criteria."))
     else:

--- a/ytcc/config.py
+++ b/ytcc/config.py
@@ -27,7 +27,8 @@ DEFAULTS: Dict[str, Dict[str, Any]] = {
     "YTCC": {
         "DBPath": "~/.local/share/ytcc/ytcc.db",
         "DownloadDir": "~/Downloads",
-        "mpvFlags": "--really-quiet --ytdl --ytdl-format=bestvideo[height<=?1080]+bestaudio/best"
+        "mpvFlags": "--really-quiet --ytdl --ytdl-format=bestvideo[height<=?1080]+bestaudio/best",
+        "orderBy": "channel_id,publish_date"
     },
     "youtube-dl": {
         "format": "bestvideo[height<=?1080]+bestaudio/best",
@@ -106,6 +107,7 @@ class Config(object):
         self.download_dir = os.path.expanduser(config["YTCC"]["DownloadDir"])
         self.db_path = os.path.expanduser(config["YTCC"]["DBPath"])
         self.mpv_flags = re.compile("\\s+").split(config["YTCC"]["mpvFlags"])
+        self.orderby = config["YTCC"]["orderBy"].split(",")
         self.table_format = config["TableFormat"]
         self.youtube_dl = _YTDLConf(config["youtube-dl"])
         self.quickselect = _QuickSelectConf(config["quickselect"])

--- a/ytcc/config.py
+++ b/ytcc/config.py
@@ -107,7 +107,7 @@ class Config(object):
         self.download_dir = os.path.expanduser(config["YTCC"]["DownloadDir"])
         self.db_path = os.path.expanduser(config["YTCC"]["DBPath"])
         self.mpv_flags = re.compile("\\s+").split(config["YTCC"]["mpvFlags"])
-        self.orderby = config["YTCC"]["orderBy"].split(",")
+        self.orderby = [col.strip() for col in config["YTCC"]["orderBy"].split(",")]
         self.table_format = config["TableFormat"]
         self.youtube_dl = _YTDLConf(config["youtube-dl"])
         self.quickselect = _QuickSelectConf(config["quickselect"])

--- a/ytcc/core.py
+++ b/ytcc/core.py
@@ -364,7 +364,8 @@ class Ytcc:
             return self.db.search(self.search_filter)
 
         return self.db.get_videos(self.channel_filter, self.date_begin_filter,
-                                  self.date_end_filter, self.include_watched_filter)
+                                  self.date_end_filter, self.include_watched_filter,
+                                  self.config.orderby)
 
     def _get_filtered_video_ids(self) -> List[int]:
         return list(map(lambda video: video.id, self.list_videos()))

--- a/ytcc/core.py
+++ b/ytcc/core.py
@@ -49,6 +49,10 @@ class BadURLException(YtccException):
     """Raised when a given URL does not refer to a YouTube channel."""
     pass
 
+class BadConfigException(YtccException):
+    """Raised when a configuration option is invalid or unknown."""
+    pass
+
 
 class DuplicateChannelException(YtccException):
     """Raised when trying to subscribe to a channel the second (or more) time."""
@@ -381,11 +385,11 @@ class Ytcc:
             return videos
                 
         fields: List[str] = list()
-        for i in self.config.orderby:
-            if not(i in vars(Video)['_fields']):
-                print(_("Ignoring unknown orderBy option: {col}").format(col=i))
+        for col in self.config.orderby:
+            if not(col in vars(Video)['_fields']):
+                raise BadConfigException("Unknown orderBy option: {col}".format(col=col))
             else:
-                fields.append(i)
+                fields.append(col)
         
         # Create a function that takes a video and returns a list of attributes
         key = lambda v: [getattr(v, field) for field in fields]

--- a/ytcc/database.py
+++ b/ytcc/database.py
@@ -163,7 +163,8 @@ class Database:
         return [Channel(*x) for x in result]
 
     def get_videos(self, channel_filter: Optional[List[str]] = None, begin_timestamp: float = 0,
-                   end_timestamp: float = 0, include_watched: bool = True) -> List[Video]:
+                   end_timestamp: float = 0, include_watched: bool = True, 
+                   orderby: Optional[List[str]]=None) -> List[Video]:
         """Returns a list of videos that were published after and before the given timestamps. The
         videos are published by the channels in channelFilter.
 
@@ -172,11 +173,36 @@ class Database:
             begin_timestamp (int): timestamp in seconds
             end_timestamp (int): timestamp in seconds
             include_watched (bool): true, if watched videos should be included in the result
+            orderby (list): the list of parameters by which to sort the results, highest priority first
 
         Returns (list):
             A list of ytcc.video.Video
         """
-
+        
+        # Convert options from config file to the strings used in the database.
+        config_to_query_param : Dict[str, str] = {
+                "id"          : "v.id",
+                "title"       : "v.title",
+                "description" : "v.description",
+                "publish_date": "v.publish_date",
+                "watched"     : "v.watched",
+                "channel_id"  : "c.id",
+                "channel_name": "c.displayname",
+            }
+        
+        # If no argument is passed, use a default.
+        sort_params : str = "c.id, v.publish_date"
+        if orderby:
+            sort_list : List[str] = list()
+            for col in orderby:
+                # Take care of extra whitespace
+                col=col.strip()
+                if not col in config_to_query_param.keys():
+                    print(_("Ignoring unknown orderBy option: {col}").format(col=col))
+                else:
+                    sort_list.append(config_to_query_param[col])
+            sort_params = ", ".join(sort_list)
+        
         sql = """
             select
                 v.id,
@@ -192,8 +218,8 @@ class Database:
                 and v.publish_date < @end_timestamp
                 and (@include_watched or v.watched = 0)
                 and (@all_channels or c.displayname in """ + \
-              self._make_place_holder(channel_filter) + """)
-            order by c.id, v.publish_date asc;
+              self._make_place_holder(channel_filter) + f""")
+            order by {sort_params} asc;
             """
 
         channel_names = channel_filter.copy() if channel_filter is not None else []


### PR DESCRIPTION
When no video IDs are selected, videos are sorted by date, rather than ID.
When videos are listed, they are also listed by date.