### PR TITLE
Ability to play non-youtube video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# ytcc - The YouTube channel checker
+# ytcc - The channel checker
 
-Command Line tool to keep track of your favourite YouTube channels without signing up for a Google account.
-
+Command Line tool to keep track of your videos channels (principly youtube) without signing up your account.
+please note that non-youtube channel are really slow to update.
 
 ## Installation
 ### Arch Linux

--- a/po/ytcc.pot
+++ b/po/ytcc.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: ytcc 1.8.0\n"
+"Project-Id-Version: ytcc 1.8.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-01 08:57+0100\n"
+"POT-Creation-Date: 2019-05-26 16:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -86,99 +86,102 @@ msgstr ""
 msgid "Press Enter to continue"
 msgstr ""
 
-#: ytcc/cli.py:252
-msgid "Video description:"
+#: ytcc/cli.py:259
+msgid "Title:   "
 msgstr ""
 
-#: ytcc/cli.py:262
-#, python-brace-format
-msgid "Playing \"{video.title}\" by \"{video.channel.displayname}\"..."
+#: ytcc/cli.py:261
+msgid "Channel: "
 msgstr ""
 
-#: ytcc/cli.py:266
+#: ytcc/cli.py:268
+msgid "Video description"
+msgstr ""
+
+#: ytcc/cli.py:281
 msgid ""
 "WARNING: The video player terminated with an error.\n"
 "         The last video is not marked as watched!"
 msgstr ""
 
-#: ytcc/cli.py:299
+#: ytcc/cli.py:314
 msgid "Yes"
 msgstr ""
 
-#: ytcc/cli.py:299
+#: ytcc/cli.py:314
 msgid "No"
 msgstr ""
 
-#: ytcc/cli.py:318
+#: ytcc/cli.py:333
 #, python-brace-format
 msgid "Downloading \"{video.title}\" by \"{video.channel.displayname}\"..."
 msgstr ""
 
-#: ytcc/cli.py:321
+#: ytcc/cli.py:336
 msgid "An Error occured while downloading the video"
 msgstr ""
 
-#: ytcc/cli.py:329
+#: ytcc/cli.py:344
 msgid "No videos were marked as watched"
 msgstr ""
 
-#: ytcc/cli.py:335
+#: ytcc/cli.py:350
 msgid "Following videos were marked as watched:"
 msgstr ""
 
-#: ytcc/cli.py:346
+#: ytcc/cli.py:361
 msgid "No videos to watch. No videos match the given criteria."
 msgstr ""
 
-#: ytcc/cli.py:363
+#: ytcc/cli.py:378
 msgid "Updating channels..."
 msgstr ""
 
-#: ytcc/cli.py:371
+#: ytcc/cli.py:386
 msgid "No videos to list. No videos match the given criteria."
 msgstr ""
 
-#: ytcc/cli.py:380
+#: ytcc/cli.py:395
 msgid "No channels added, yet."
 msgstr ""
 
-#: ytcc/cli.py:391
-msgid "{!r} is not a valid YouTube URL"
-msgstr ""
-
-#: ytcc/cli.py:393
-msgid "You are already subscribed to {!r}"
-msgstr ""
-
-#: ytcc/cli.py:395
-msgid "The channel {!r} does not exist"
+#: ytcc/cli.py:406
+msgid "{!r} is not a valid URL"
 msgstr ""
 
 #: ytcc/cli.py:408
-msgid "Error: The given channel does not exist."
+msgid "You are already subscribed to {!r}"
 msgstr ""
 
 #: ytcc/cli.py:410
+msgid "The channel {!r} does not exist"
+msgstr ""
+
+#: ytcc/cli.py:423
+msgid "Error: The given channel does not exist."
+msgstr ""
+
+#: ytcc/cli.py:425
 msgid "Error: The new name already exists."
 msgstr ""
 
-#: ytcc/cli.py:415
+#: ytcc/cli.py:430
 msgid "Cleaning up database..."
 msgstr ""
 
-#: ytcc/cli.py:421
+#: ytcc/cli.py:436
 msgid "Importing..."
 msgstr ""
 
-#: ytcc/cli.py:424
+#: ytcc/cli.py:439
 msgid "Subscriptions"
 msgstr ""
 
-#: ytcc/cli.py:430
+#: ytcc/cli.py:445
 msgid "The given file is not valid YouTube export file"
 msgstr ""
 
-#: ytcc/cli.py:584
+#: ytcc/cli.py:599
 msgid "Bye..."
 msgstr ""
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def compile_translations():
 
 setup(
     name='ytcc',
-    description='A YouTube subscription tool',
+    description='A videos subscription tool',
     long_description=ytcc.__doc__,
     version=ytcc.__version__,
     url='https://github.com/woefe/ytcc',

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,9 +1,9 @@
 name: ytcc
 version: git
-summary: ytcc - The YouTube channel checker
+summary: ytcc - The channel checker
 description: |
-  Command Line tool to keep track of your favourite YouTube channels without
-  signing up for a Google account.
+  Command Line tool to keep track of your videos channels (principly youtube)
+  without signing up your account.
 
 grade: devel
 confinement: devmode

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -310,7 +310,7 @@ def print_videos(videos: Iterable[Video],
             datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M"),
             str(video.channel.displayname),
             str(video.title),
-            ytcc_core.get_youtube_video_url(video.yt_videoid),
+            ytcc_core.get_video_url(video),
             _("Yes") if video.watched else _("No")
         ]
 

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -403,7 +403,7 @@ def add_channel(name: str, channel_url: str) -> None:
     try:
         ytcc_core.add_channel(name, channel_url)
     except BadURLException:
-        print(_("{!r} is not a valid YouTube URL").format(channel_url))
+        print(_("{!r} is not a valid URL").format(channel_url))
     except DuplicateChannelException:
         print(_("You are already subscribed to {!r}").format(name))
     except ChannelDoesNotExistException:

--- a/ytcc/core.py
+++ b/ytcc/core.py
@@ -76,16 +76,19 @@ class Ytcc:
         self.database.close()
 
     @staticmethod
-    def get_youtube_video_url(yt_videoid: Optional[str]) -> str:
-        """Return the YouTube URL for the given youtube video ID.
+    def get_video_url(video) -> str:
+        """Return the URL for the given video.
 
-        :param yt_videoid:  The YouTube video ID.
-        :return: The YouTube URL for the given youtube video ID.
+        :param video:  The video.
+        :return: The URL for the given video.
         """
-        if yt_videoid is None:
-            raise YtccException("Video id is none!")
+        if video.yt_videoid is None:
+            raise YtccException("Video id is None!")
 
-        return f"https://www.youtube.com/watch?v={yt_videoid}"
+        if video.is_youtube_dl:
+            return video.yt_videoid
+        else:
+            return f"https://www.youtube.com/watch?v={yt_videoid}"
 
     def set_channel_filter(self, channel_filter: List[str]) -> None:
         """Set the channel filter.
@@ -196,7 +199,7 @@ class Ytcc:
         if video:
             try:
                 mpv_result = subprocess.run(["mpv", *no_video_flag, *self.config.mpv_flags,
-                                             self.get_youtube_video_url(video.yt_videoid)])
+                                             self.get_video_url(video)])
             except FileNotFoundError:
                 raise YtccException("Could not locate the mpv video player!")
 
@@ -254,7 +257,7 @@ class Ytcc:
                 ydl_opts["postprocessors"] = [{"key": "FFmpegEmbedSubtitle"}]
 
         with youtube_dl.YoutubeDL(ydl_opts) as ydl:
-            url = self.get_youtube_video_url(video.yt_videoid)
+            url = self.get_video_url(video)
             try:
                 info = ydl.extract_info(url, download=False, process=False)
                 if info.get("is_live", False) and conf.skip_live_stream:

--- a/ytcc/database.py
+++ b/ytcc/database.py
@@ -34,7 +34,7 @@ class Channel(Base):
     id = Column(Integer, primary_key=True)
     displayname = Column(String, unique=True, nullable=False)
     yt_channelid = Column(String, unique=True, nullable=False)
-
+    is_youtube_dl = Column(Boolean)
     videos = relationship("Video", back_populates="channel",
                           cascade="all, delete, delete-orphan")
 
@@ -51,6 +51,7 @@ class Video(Base):
     watched = Column(Boolean)
 
     channel = relationship("Channel", back_populates="videos")
+    is_youtube_dl = Column(Boolean)
 
 
 class Database:

--- a/ytcc/utils.py
+++ b/ytcc/utils.py
@@ -15,6 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with ytcc.  If not, see <http://www.gnu.org/licenses/>.
+import subprocess
+import json
 
 from typing import TypeVar, Optional, Callable
 
@@ -26,3 +28,24 @@ def unpack_optional(elem: Optional[T], default: Callable[[], T]) -> T:
     if elem is None:
         return default()
     return elem
+
+def list_playlist(playlist_url:str):
+    output = subprocess.check_output(["youtube-dl", playlist_url, "--flat-playlist", "--dump-single-json", "--playlist-end","10"])
+    playlist_json = json.loads(output)
+
+    videos = []
+
+    assert playlist_json["_type"] == "playlist"
+    playlist_title = playlist_json["title"]
+
+    for entry in playlist_json["entries"]:
+        videos.append({
+            "url": entry["url"],
+            "title": entry["title"]
+        })
+
+    return videos, playlist_title
+
+def get_video_information(video_url:str):
+    output = subprocess.check_output(["youtube-dl", video_url, "--dump-single-json"])
+    return json.loads(output)


### PR DESCRIPTION
youtube-dl has an option to list video in playlist (including channel). I've used this ability (limiting it to 10 result) to be able to follow non-youtube channel.
There are however multiple problem:
- It is slow (youtube-dl need to browse 10 page to get the metadata for the 10 videos. It may be possible to optimise this, as we can only check for the description and date of video where this value is not already know. However, I've a bad knowledge in database).
- It don't work with previous version database (again, I'm not good at database, and I'm not sure of how to do this. The most simple will be to set a default value, but that doesn't appear to work)
- It made the database look weird (uploader id is a video channel, and think like that. If that is important, the database could be migrated, possibly with the same method that the one that will be used for the inconpatibility problem).

I've done this because I want an easy way to follow peertube channel (will just need to integrate peertube channel to youtube-dl).