### PR TITLE
Update site_name_node

### DIFF
--- a/ytcc/core.py
+++ b/ytcc/core.py
@@ -288,7 +288,7 @@ class Ytcc:
 
         parser = etree.HTMLParser()
         root = etree.parse(StringIO(response), parser).getroot()
-        site_name_node = root.xpath('/html/head/meta[@property="og:site_name"]')
+        site_name_node = root.xpath('/html/body/meta[@property="og:site_name"]')
         channel_id_node = root.xpath('//meta[@itemprop="channelId"]')
 
         if not site_name_node or site_name_node[0].attrib.get("content", "") != "YouTube":


### PR DESCRIPTION
It seems like the site name node has been moved to `<body>`, which caused the site check to fail.
Fixes: #30 