### PR TITLE
Add raise when adding video to unknown playlist

### DIFF
--- a/ytcc/database.py
+++ b/ytcc/database.py
@@ -24,7 +24,7 @@ from typing import List, Iterable, Any, Optional, Dict, overload, Tuple
 
 from ytcc import config
 from ytcc.config import Direction, VideoAttr
-from ytcc.exceptions import IncompatibleDatabaseVersion
+from ytcc.exceptions import IncompatibleDatabaseVersion, PlaylistDoesNotExistException
 from ytcc.utils import unpack_optional
 
 logger = logging.getLogger(__name__)
@@ -227,7 +227,11 @@ class Database:
             """
         with self.connection as con:
             cursor = con.execute("SELECT id FROM playlist WHERE name = ?", (playlist.name,))
-            playlist_id = cursor.fetchone()["id"]
+            fetch=cursor.fetchone()
+            if fetch is None:
+                raise PlaylistDoesNotExistException(
+                    f"Playlist \"{playlist.name}\" is not in the database.")
+            playlist_id = fetch["id"]
             for video in videos:
                 cursor.execute(insert_video, asdict(video))
                 cursor.execute(insert_playlist, (playlist_id, video.url))


### PR DESCRIPTION
When adding using `database.add_videos()` to add to a playlist that doesn't exist, a `TypeError` is raised, because of indexing None. Example below:
```
Traceback (most recent call last):
  File "import_db.py", line 54, in <module>
    ytcc.database.add_videos(l, ytcc.core.Playlist(current_pl, url))
  File "/ytcc/ytcc/ytcc/database.py",
    playlist_id = cursor.fetchone()["id"]
TypeError: 'NoneType' object is not subscriptable
```
This PR adds a check to the value of `cursor.fetchone()`. If it is `None`, a `PlaylistDoesNotExistException` is then raised since there is no such playlist.