### PR TITLE
Add migration script that only relies on v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ mpv_flags = --ytdl --ytdl-format=bestvideo[height<=?1080]+bestaudio/best
 
 # Defines the order of video listings.
 # Possible options: id, url, title, description, publish_date, watched, duration, extractor_hash,
-# playlists. # Every option must be suffixed with :desc or :asc for descending or ascending sort.
+# playlists. Every option must be suffixed with :desc or :asc for descending or ascending sort.
 order_by = playlists:asc, publish_date:desc
 
 # Default attributes shown in video listings.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ytcc
 
-Command line tool to keep track of your favourite playlists on YouTube and many other places.
+Command line tool to keep track of your favorite playlists on YouTube and many other places.
 
 **The second beta release of ytcc 2.0.0 is out!**
 Read [the migration guide](#migrating-from-version-1) before upgrading to 2.0.0 or later!
@@ -15,10 +15,10 @@ pip install ytcc
 
 ### Arch Linux
 Install [ytcc-git](https://aur.archlinux.org/packages/ytcc-git/) from the AUR.
-The [ytcc](https://aur.archlinux.org/packages/ytcc/) will be upgraded to version 2.0.0, when it has a stable release.
+The [ytcc](https://aur.archlinux.org/packages/ytcc/) package will be upgraded to version 2.0.0, when it has a stable release.
 
 ### Without installation
-You can start ytcc directly from the cloned repo, if all the requirements are installed.
+You can start ytcc directly from the cloned repo, if all requirements are installed.
 
 ```shell script
 ./ytcc.py --help
@@ -36,8 +36,24 @@ Optional requirements:
 ## Migrating from version 1
 Versions 2.0.0 and later are not compatible with previous databases and configuration files!
 You need to follow several steps to migrate your subscriptions to 2.0.0 or later.
-Unfortunately, you will lose the watched status of all videos during this process.
+Unfortunately, videos migrated from version 1 always have the duration attribute set to zero.
 
+*Note: If you adjusted the database location in version 1 you have to adjust the paths used below*
+
+1. Upgrade ytcc to version 2.0.0 or later.
+2. Download the migration script from [here](https://github.com/woefe/ytcc/tree/master/scripts/migrate.py).
+3. Rename your v1 database.
+    ```shell script
+    mv ~/.local/share/ytcc/ytcc.db ~/.local/share/ytcc/ytcc.db.v1
+    ```
+4. Migrate the database.
+    ```shell script
+    python3 path/to/migrate.py --olddb ~/.local/share/ytcc/ytcc.db.v1 --newdb ~/.local/share/ytcc/ytcc.db
+    ```
+5. (Optional) Take a look at the [configuration](#configuration) to see what's new and update your config.
+
+###Alternative migrations
+####Channel export and import
 1. Export your subscriptions with ytcc 1.8.5 **before** upgrading to 2.0.0 or later
     ```shell script
     ytcc --export-to subscriptions.opml
@@ -48,12 +64,11 @@ Unfortunately, you will lose the watched status of all videos during this proces
     ```shell script
     ytcc import subscriptions.opml
     ```
----
-**Other options**:
-- If you think the procedure described above is not worth the effort, you can start from scratch by removing the `~/.config/ytcc` directory.
-- If you are not satisfied with the options here, write a migration script!
-    See [issue 42](https://github.com/woefe/ytcc/issues/42).
-    Pull Requests welcome ❤
+5. (Optional) You might also want to adjust your config to the new format. See [Configuration](#configuration).
+
+#### Start from scratch
+If you think the procedures described above are not worth the effort, you can start from scratch by removing the `~/.config/ytcc` directory.
+
 
 ## Usage
 
@@ -100,7 +115,7 @@ ytcc ls -p "NCS: House" | ytcc play --audio-only
 
 **Alternative terminal interface built on [fzf](https://github.com/junegunn/fzf)**.
 Requires fzf version 0.19.0 or newer, preferably after [6f9664d](https://github.com/junegunn/fzf/commit/6f9663da62a84fcce8992c63dad8016f3107364d).
-Otherwise you might experience some issues.
+Otherwise, you might experience some issues.
 Script is available [here](https://github.com/woefe/ytcc/tree/master/scripts/ytccf.sh).
 ```shell script
 ytccf.sh
@@ -130,8 +145,8 @@ download_dir = ~/Downloads
 mpv_flags = --ytdl --ytdl-format=bestvideo[height<=?1080]+bestaudio/best
 
 # Defines the order of video listings.
-# Possible options: id, url, title, description, publish_date, watched, duration, extractor_hash, playlists.
-# Every option must be suffixed with :desc or :asc for descending or ascending sort.
+# Possible options: id, url, title, description, publish_date, watched, duration, extractor_hash,
+# playlists. # Every option must be suffixed with :desc or :asc for descending or ascending sort.
 order_by = playlists:asc, publish_date:desc
 
 # Default attributes shown in video listings.
@@ -150,13 +165,13 @@ db_path = ~/.local/share/ytcc/ytcc.db
 date_format = %Y-%m-%d
 
 # Default failure threshold before a video is ignored.
-# When a video could not be updated repeatedly, it will be ignored by ytcc after `max_update_fail` attempts.
-# This setting can be overridden with the --max-fail commandline parameter.
+# When a video could not be updated repeatedly, it will be ignored by ytcc after `max_update_fail`
+# attempts. This setting can be overridden with the --max-fail commandline parameter.
 max_update_fail = 5
 
 # Default update backlog.
-# The update command will only the first `max_update_backlog` videos of a playlist to improve performance.
-# This setting can be overridden with the --max-backlog commandline parameter.
+# The update command will only the first `max_update_backlog` videos of a playlist to improve
+# performance. This setting can be overridden with the --max-backlog commandline parameter.
 max_update_backlog = 20
 
 # Ignore videos that have an age limit higher than the one specified here.
@@ -192,8 +207,8 @@ format = bestvideo[height<=?1080]+bestaudio/best
 # Output template (see OUTPUT TEMPLATE in youtube-dl manpage)
 outputtemplate = %(title)s.%(ext)s
 
-# If a merge is required according to format selection, merge to the given container format. One of
-# mkv, mp4, ogg, webm, flv
+# If a merge is required according to format selection, merge to the given container format.
+# One of mkv, mp4, ogg, webm, flv
 mergeoutputformat = mkv
 
 # Loglevel options: quiet, normal, verbose

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import sqlite3
+#  ytcc - The YouTube channel checker
+#  Copyright (C) 2020  Wolfgang Popp
+#
+#  This file is part of ytcc.
+#
+#  ytcc is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ytcc is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ytcc.  If not, see <http://www.gnu.org/licenses/>.
+import sys
+import textwrap
+from datetime import datetime
+from pathlib import Path
+
+
+def error(message: str):
+    print("Error:", message)
+
+
+def usage():
+    help_text = f"""\
+    Usage: {sys.argv[0]} --olddb PATH --newdb PATH
+
+      Ytcc migration script.
+
+      Migrates the database used in version 1 to compatible database for version 2.
+
+    OPTIONS:
+      --help     Show this message and exit.
+      --olddb    Path to the old database file.
+      --newdb    Path to the new database file.
+    """
+    print(textwrap.dedent(help_text))
+
+
+it = iter(sys.argv[1:])
+arg = next(it, None)
+old_db = None
+new_db = None
+
+while arg:
+    if arg == "--help":
+        usage()
+        sys.exit(1)
+    elif arg == "--olddb":
+        old_db = next(it, None)
+    elif arg == "--newdb":
+        new_db = next(it, None)
+    arg = next(it, None)
+
+if None in (old_db, new_db):
+    error(f"Missing command line option. Try {sys.argv[0]} --help for help.")
+    sys.exit(1)
+
+old_db = Path(old_db)
+new_db = Path(new_db)
+
+if not old_db.is_file():
+    error(f"{old_db} is not a file!")
+    sys.exit(1)
+
+if not new_db.parent.is_dir():
+    error(f"{new_db.parent} is not a directory!")
+    sys.exit(1)
+
+try:
+    import ytcc
+    import ytcc.config
+except ImportError:
+    error("Cannot import ytcc! Make sure ytcc version 2.0.0 or later is installed!")
+    sys.exit(1)
+
+if not ytcc.__version__.startswith("2"):
+    error(f"ytcc version {ytcc.__version__} is installed. Version 2.0.0 or later is required")
+    sys.exit(1)
+
+ytcc.config.ytcc.db_path = str(new_db)
+core_v2 = ytcc.Ytcc()
+con_v1 = sqlite3.connect(old_db)
+video_query = """
+    SELECT yt_videoid, title, description, publish_date, watched
+    FROM video WHERE publisher = ?
+    """
+
+for c_name, yt_channelid in con_v1.execute("SELECT displayname, yt_channelid FROM channel"):
+    url = f"https://www.youtube.com/channel/{yt_channelid}/videos"
+    try:
+        core_v2.add_playlist(c_name, url)
+    except ytcc.BadURLException:
+        print(
+            f"Ignoring {c_name}, because it is not supported by "
+            "youtube-dl or does not exist any more"
+        )
+        continue
+    except ytcc.NameConflictError:
+        print(f"{c_name} is already subscribed.")
+
+    print(f"Adding videos for {c_name}")
+    videos = (
+        ytcc.Video(
+            url=f"https://www.youtube.com/watch?v={yt_videoid}",
+            title=title,
+            description=description,
+            publish_date=float(publish_date),
+            watched=bool(int(watched)),
+            duration=0,
+            extractor_hash=f"youtube {yt_videoid}"
+        )
+        for yt_videoid, title, description, publish_date, watched
+        in con_v1.execute(video_query, (yt_channelid,))
+    )
+    core_v2.database.add_videos(videos, ytcc.Playlist(c_name, url))

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -20,7 +20,6 @@ import sqlite3
 #  along with ytcc.  If not, see <http://www.gnu.org/licenses/>.
 import sys
 import textwrap
-from datetime import datetime
 from pathlib import Path
 
 
@@ -46,25 +45,25 @@ def usage():
 
 it = iter(sys.argv[1:])
 arg = next(it, None)
-old_db = None
-new_db = None
+old_db_arg = None
+new_db_arg = None
 
 while arg:
     if arg == "--help":
         usage()
         sys.exit(1)
     elif arg == "--olddb":
-        old_db = next(it, None)
+        old_db_arg = next(it, None)
     elif arg == "--newdb":
-        new_db = next(it, None)
+        new_db_arg = next(it, None)
     arg = next(it, None)
 
-if None in (old_db, new_db):
+if old_db_arg is None or new_db_arg is None:
     error(f"Missing command line option. Try {sys.argv[0]} --help for help.")
     sys.exit(1)
 
-old_db = Path(old_db)
-new_db = Path(new_db)
+old_db = Path(old_db_arg)
+new_db = Path(new_db_arg)
 
 if not old_db.is_file():
     error(f"{old_db} is not a file!")

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import sqlite3
 #  ytcc - The YouTube channel checker
 #  Copyright (C) 2020  Wolfgang Popp
 #
@@ -18,6 +17,8 @@ import sqlite3
 #
 #  You should have received a copy of the GNU General Public License
 #  along with ytcc.  If not, see <http://www.gnu.org/licenses/>.
+
+import sqlite3
 import sys
 import textwrap
 from pathlib import Path

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 
 def error(message: str):
-    print("Error:", message)
+    print("Error:", message, file=sys.stderr)
 
 
 def usage():

--- a/ytcc/__init__.py
+++ b/ytcc/__init__.py
@@ -27,9 +27,12 @@ __version__ = "2.0.0b2"
 __author__ = __maintainer__ = "Wolfgang Popp"
 __email__ = "mail@wolfgang-popp.de"
 
-from pathlib import Path
 import gettext
 import sys
+from pathlib import Path
+from ytcc.database import Database, MappedVideo, Video, MappedPlaylist, Playlist
+from ytcc.core import Ytcc
+from ytcc.exceptions import *
 
 
 def _get_translations_path() -> str:

--- a/ytcc/core.py
+++ b/ytcc/core.py
@@ -156,10 +156,6 @@ class Ytcc:
         self.date_end_filter = (0.0, False)
         self.include_watched_filter: Optional[bool] = False
 
-    def __del__(self):
-        if self._database is not None:
-            self._database.close()
-
     def __enter__(self) -> "Ytcc":
         return self
 


### PR DESCRIPTION
This migration script relies only on v2 being installed and available as Python import. It reads subscriptions and videos directly from the v1 SQL database and adds them to a v2 database. The duration column in v2 is always set to zero.

This is a possible replacement for PR #50 and fixes #42 