### PR TITLE
Add Gentoo installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Install [ytcc-git](https://aur.archlinux.org/packages/ytcc-git/) from the AUR.
 The [ytcc](https://aur.archlinux.org/packages/ytcc/) package will be upgraded to version 2.0.0, when it has a stable release.
 
 ### Gentoo
+Note: this is maintained by [@EmRowlands](https://github.com/EmRowlands),
+please report installation errors to the erowl-overlay issue tracker before the
+main ytcc tracker.
+
 Add the `erowl-overlay` using `eselect-repository` (or layman):
 
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Add the `erowl-overlay` using `eselect-repository` (or layman):
 eselect repository add erowl-overlay git https://gitlab.com/EmRowlands/erowl-overlay.git
 ```
 
-Install `net-misc/ytcc`.
+Install `net-misc/ytcc`. Currently (October 2020), ytcc v1 is stable and ytcc
+v2 betas are `~arch`. A 9999 ebuild is also avaliable.
 
 ### Without installation
 You can start ytcc directly from the cloned repo, if all requirements are installed.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ pip install ytcc
 Install [ytcc-git](https://aur.archlinux.org/packages/ytcc-git/) from the AUR.
 The [ytcc](https://aur.archlinux.org/packages/ytcc/) package will be upgraded to version 2.0.0, when it has a stable release.
 
+### Gentoo
+Add the `erowl-overlay` using `eselect-repository` (or layman):
+
+```
+eselect repository add erowl-overlay git https://gitlab.com/EmRowlands/erowl-overlay.git
+```
+
+Install `net-misc/ytcc`.
+
 ### Without installation
 You can start ytcc directly from the cloned repo, if all requirements are installed.
 


### PR DESCRIPTION
This pull request will add installation instructions for Gentoo. The ebuild files for installing ytcc can be found [here](https://gitlab.com/EmRowlands/erowl-overlay/-/tree/main/net-misc/ytcc).

Currently, `FEATURES=test` is not implemented, but I will add this at a later date. No changes to the install instructions will be required.