### PR TITLE
Remove subshell

### DIFF
--- a/scripts/ytccf.sh
+++ b/scripts/ytccf.sh
@@ -122,7 +122,7 @@ check_cmd ytcc
 check_cmd fzf
 
 eval "$make_table" |
-    fzf --preview "ytcc --output xsv --separator ';' list -a description -i \$(echo {} | cut -d ' ' -f 2)" \
+    fzf --preview "ytcc --output xsv --separator ';' list -a description -i {1}" \
         --multi \
         --layout reverse \
         --preview-window down:55%:wrap \


### PR DESCRIPTION
fzf supports field index expression, that trims the value by default, so a subshell is not needed.

It also has the advantage not to rely on shell syntax, because since `$SHELL` variable is not set, `fzf` use the user shell to execute the preview, and it can have wrong result. I was impacted as a fish user.