### PR TITLE
Add option to update playlists in reverse order

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ video_attrs = id, title, publish_date, duration, playlists
 
 # Default attributes shown in playlist/subscription listings.
 # Some ytcc commands allow overriding the default set here in the config.
-playlist_attrs = name, url, tags
+playlist_attrs = name, url, reverse, tags
 
 # Path where the database is stored.
 # Can be used to sync the database between multiple machines.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,7 +2,9 @@ from ytcc import Video, Playlist
 
 WEBDRIVER_PLAYLIST = Playlist(
     "WebDriver",
-    "https://www.youtube.com/playlist?list=UUsLiV4WJfkTEHH0b9PmRklw")
+    "https://www.youtube.com/playlist?list=UUsLiV4WJfkTEHH0b9PmRklw",
+    False
+)
 
 WEBDRIVER_VIDEOS = [
     Video("https://www.youtube.com/watch?v=XI7Cxdj2pAQ", "StmpavbMLW", "tmpavbMLW", 1572476400.0,

--- a/test/data/ytcc_test.conf
+++ b/test/data/ytcc_test.conf
@@ -25,7 +25,7 @@ download_dir = /tmp/ytcc
 mpv_flags = --really-quiet --ytdl --ytdl-format=bestvideo[height<=?1080]+bestaudio/best
 order_by = playlists:asc, publish_date:desc
 video_attrs = id, title, publish_date, duration, playlists
-playlist_attrs = name, url, tags
+playlist_attrs = name, url, reverse, tags
 db_path = /tmp/ytcc/ytcc.db
 date_format = %Y-%m-%d
 max_update_fail = 5

--- a/ytcc/__init__.py
+++ b/ytcc/__init__.py
@@ -31,7 +31,6 @@ import gettext
 import sys
 from pathlib import Path
 from ytcc.database import Database, MappedVideo, Video, MappedPlaylist, Playlist
-from ytcc.core import Ytcc
 from ytcc.exceptions import *
 
 

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -186,7 +186,9 @@ def cli(ctx: click.Context, conf: Path, loglevel: str, output: str, separator: s
 @click.argument("name")
 @click.argument("url")
 @click.option("--reverse", is_flag=True, default=False,
-              help="Check the playlist in reverse order. Slows down updating!")
+              help="Check the playlist in reverse order. This should be used for playlists where "
+                   "the latest videos are added to the end of the playlist. WARNING: Using this "
+                   "option on large playlists slows down updating!")
 @pass_ytcc
 def subscribe(ytcc: core.Ytcc, name: str, url: str, reverse: bool):
     """Subscribe to a playlist.

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -185,15 +185,17 @@ def cli(ctx: click.Context, conf: Path, loglevel: str, output: str, separator: s
 @cli.command()
 @click.argument("name")
 @click.argument("url")
+@click.option("--reverse", is_flag=True, default=False,
+              help="Check the playlist in reverse order. Slows down updating!")
 @pass_ytcc
-def subscribe(ytcc: core.Ytcc, name: str, url: str):
+def subscribe(ytcc: core.Ytcc, name: str, url: str, reverse: bool):
     """Subscribe to a playlist.
 
     The NAME argument is the name used to refer to the playlist. The URL argument is the URL to a
     playlist that is supported by youtube-dl.
     """
     try:
-        ytcc.add_playlist(name, url)
+        ytcc.add_playlist(name, url, reverse)
     except BadURLException as bad_url:
         logger.error("The given URL does not point to a playlist or is not supported by "
                      "youtube-dl")

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -245,6 +245,24 @@ def rename(ytcc: core.Ytcc, old: str, new: str):
         raise Exit(1) from nce
 
 
+@cli.command("reverse")
+@click.argument("playlists", nargs=-1, autocompletion=playlist_completion)
+@pass_ytcc
+def reverse_playlist(ytcc: core.Ytcc, playlists: Tuple[str, ...]):
+    """Toggle the update behavior of playlists.
+
+    Playlists updated in reverse might lead to slow updates with the `update` command.
+    """
+    for playlist in playlists:
+        try:
+            ytcc.reverse_playlist(playlist)
+        except PlaylistDoesNotExistException as err:
+            logger.error("Could not reverse playlist '%s', because it doesn't exist", playlist)
+            raise Exit(1) from err
+        else:
+            logger.info("Reversed playlist '%s'", playlist)
+
+
 @cli.command()
 @click.option("--attributes", "-a", type=CommaList(PlaylistAttr.from_str),
               help="Attributes of the playlist to be included in the output. "

--- a/ytcc/config.py
+++ b/ytcc/config.py
@@ -90,6 +90,7 @@ class PlaylistAttr(str, Enum):
     NAME = "name"
     URL = "url"
     TAGS = "tags"
+    REVERSE = "reverse"
 
     @staticmethod
     def from_str(string: str) -> "PlaylistAttr":

--- a/ytcc/core.py
+++ b/ytcc/core.py
@@ -312,8 +312,9 @@ class Ytcc:
             if self._is_playlist_reverse(playlist):
                 logger.warning(
                     "The playlist seems to be updated in opposite order. You probably won't "
-                    "receive any updates for this playlist. "
-                    "See `ytcc subscribe --help` for more details on the `--reverse` option."
+                    "receive any updates for this playlist. Use `ytcc reverse '%s'` to change the "
+                    "update behavior of the playlist.",
+                    name
                 )
 
         try:
@@ -360,6 +361,12 @@ class Ytcc:
         if not self.database.rename_playlist(oldname, newname):
             raise NameConflictError("Renaming failed. Either the old name does not exist or the "
                                     "new name is already used.")
+
+    def reverse_playlist(self, playlist: str) -> None:
+        if not self.database.reverse_playlist(playlist):
+            raise PlaylistDoesNotExistException(
+                "Could not modify the playlist, because it does not exist"
+            )
 
     def list_playlists(self) -> Iterable[MappedPlaylist]:
         return self.database.list_playlists()

--- a/ytcc/core.py
+++ b/ytcc/core.py
@@ -305,7 +305,7 @@ class Ytcc:
                 raise BadURLException("The playlist URL cannot be found")
 
             logger.info("Performing update check on 10 playlist items")
-            playlist = Fetcher(10).fetch(Playlist(name, real_url, reverse))
+            playlist = list(Fetcher(10).fetch(Playlist(name, real_url, reverse)))
             if not playlist:
                 logger.warning("The playlist might be empty")
 

--- a/ytcc/database.py
+++ b/ytcc/database.py
@@ -75,7 +75,7 @@ class MappedPlaylist(Playlist):
 
 
 class Database:
-    VERSION = 3
+    VERSION = 4
 
     def __init__(self, path: str = ":memory:"):
         is_new_db = True

--- a/ytcc/database.py
+++ b/ytcc/database.py
@@ -192,7 +192,7 @@ class Database:
             res = self.connection.execute(query, (name,))
             return res.rowcount > 0
 
-    def rename_playlist(self, oldname, newname) -> bool:
+    def rename_playlist(self, oldname: str, newname: str) -> bool:
         query = "UPDATE playlist SET name = ? WHERE name = ?"
         try:
             with self.connection:
@@ -200,6 +200,12 @@ class Database:
                 return res.rowcount > 0
         except sqlite3.IntegrityError:
             return False
+
+    def reverse_playlist(self, playlist: str) -> bool:
+        query = "UPDATE playlist SET reverse = (reverse + 1) % 2 WHERE name = ?"
+        with self.connection as con:
+            res = con.execute(query, (playlist,))
+            return res.rowcount > 0
 
     def list_playlists(self) -> Iterable[MappedPlaylist]:
         query = """

--- a/ytcc/migration.py
+++ b/ytcc/migration.py
@@ -18,7 +18,7 @@
 import sqlite3
 from datetime import datetime
 
-v3_watch_date = f"""
+V3_WATCH_DATE = f"""
 CREATE TABLE new_video
 (
     id             INTEGER        NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -63,7 +63,13 @@ ALTER TABLE new_video
 PRAGMA foreign_key_check;
 """
 
-UPDATES = ["-- noop", "-- noop", v3_watch_date]
+V4_PLAYLIST_REVERSE = """
+ALTER TABLE playlist ADD COLUMN reverse BOOLEAN;
+
+UPDATE playlist SET reverse = false WHERE reverse IS NULL;
+"""
+
+UPDATES = ["-- noop", "-- noop", V3_WATCH_DATE, V4_PLAYLIST_REVERSE]
 
 
 def migrate(old_version: int, new_version: int, db_conn: sqlite3.Connection) -> None:

--- a/ytcc/printer.py
+++ b/ytcc/printer.py
@@ -120,10 +120,11 @@ class PlaylistPrintable(Printable):
             yield asdict(playlist)
 
     def table(self) -> Table:
-        header = ["name", "url", "tags"]
+        header = ["name", "url", "reverse", "tags"]
         data = []
         for playlist in self.playlists:
-            data.append([playlist.name, playlist.url, ", ".join(playlist.tags)])
+            is_reverse = str(playlist.reverse).lower()
+            data.append([playlist.name, playlist.url, is_reverse, ", ".join(playlist.tags)])
 
         return Table(header, data)
 

--- a/ytcc/updater.py
+++ b/ytcc/updater.py
@@ -119,12 +119,11 @@ class Fetcher:
                     extractor_hash=e_hash
                 )
 
-    def fetch(self, playlist: Playlist) -> List[Video]:
-        return [
-            video
-            for entry, e_hash in self.get_unprocessed_entries(playlist)
-            if (video := self.process_entry(e_hash, entry)[1])
-        ]
+    def fetch(self, playlist: Playlist) -> Iterable[Video]:
+        for entry, e_hash in self.get_unprocessed_entries(playlist):
+            video = self.process_entry(e_hash, entry)[1]
+            if video:
+                yield video
 
 
 class Updater:

--- a/ytcc/updater.py
+++ b/ytcc/updater.py
@@ -1,0 +1,171 @@
+#  ytcc - The YouTube channel checker
+#  Copyright (C) 2021  Wolfgang Popp
+#
+#  This file is part of ytcc.
+#
+#  ytcc is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ytcc is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ytcc.  If not, see <http://www.gnu.org/licenses/>.
+import datetime
+import itertools
+import logging
+import os
+from collections import defaultdict
+from concurrent.futures.thread import ThreadPoolExecutor as Pool
+from typing import List, Tuple, Any, Optional, Iterable
+
+from ytcc import config, Playlist, Database, Video
+from ytcc.utils import take, unpack_optional, lazy_import
+
+youtube_dl = lazy_import("youtube_dl")
+
+logger = logging.getLogger(__name__)
+
+_ytdl_logger = logging.getLogger("youtube_dl")
+_ytdl_logger.propagate = False
+_ytdl_logger.addHandler(logging.NullHandler())
+YTDL_COMMON_OPTS = {
+    "logger": _ytdl_logger
+}
+
+
+class Fetcher:
+    def __init__(self, max_backlog):
+        self.max_items = max_backlog
+        self.ydl_opts = {
+            **YTDL_COMMON_OPTS,
+            "playliststart": 1,
+            "playlistend": max_backlog,
+            "noplaylist": False,
+            "age_limit": config.ytcc.age_limit
+        }
+
+    def get_unprocessed_entries(self, playlist: Playlist) -> Iterable[Tuple[Any, str]]:
+        ydl_opts = self.ydl_opts.copy()
+        ydl_opts["playlistend"] = None if playlist.reverse else self.max_items
+
+        with youtube_dl.YoutubeDL(self.ydl_opts) as ydl:
+            logger.info("Checking playlist '%s'...", playlist.name)
+            try:
+                info = ydl.extract_info(playlist.url, download=False, process=False)
+            except youtube_dl.DownloadError as download_error:
+                logging.error("Failed to get playlist %s. Youtube-dl said: '%s'",
+                              playlist.name, download_error)
+            else:
+                entries = info.get("entries", [])
+                if playlist.reverse:
+                    entries = reversed(list(entries))
+                for entry in take(self.max_items, entries):
+                    e_hash = ydl._make_archive_id(entry)  # pylint: disable=protected-access
+                    if e_hash is None:
+                        logger.warning("Ignoring malformed playlist entry from %s", playlist.name)
+                    else:
+                        yield entry, e_hash
+
+    def process_entry(self, e_hash: str, entry: Any) -> Tuple[str, Optional[Video]]:
+        with youtube_dl.YoutubeDL(self.ydl_opts) as ydl:
+            try:
+                processed = ydl.process_ie_result(entry, False)
+            except youtube_dl.DownloadError as download_error:
+                logging.warning("Failed to get a video. Youtube-dl said: '%s'", download_error)
+                return e_hash, None
+            else:
+                title = processed.get("title")
+                if not title:
+                    logger.error("Failed to process a video, because its title is missing")
+                    return e_hash, None
+
+                url = processed.get("webpage_url")
+                if not url:
+                    logger.error(
+                        "Failed to process a video '%s', because its URL is missing",
+                        title
+                    )
+                    return e_hash, None
+
+                if processed.get("age_limit", 0) > config.ytcc.age_limit:
+                    logger.warning("Ignoring video '%s' due to age limit", title)
+                    return e_hash, None
+
+                publish_date = 169201.0  # Minimum timestamp usable on Windows
+                date_str = processed.get("upload_date")
+                if date_str:
+                    publish_date = datetime.datetime.strptime(date_str, "%Y%m%d").timestamp()
+                else:
+                    logger.warning("Publication date of video '%s' is unknown", title)
+
+                duration = processed.get("duration") or -1
+                if duration < 0:
+                    logger.warning("Duration of video '%s' is unknown", title)
+
+                logger.info("Processed video '%s'", processed.get("title"))
+
+                return e_hash, Video(
+                    url=url,
+                    title=title,
+                    description=processed.get("description", ""),
+                    publish_date=publish_date,
+                    watch_date=None,
+                    duration=duration,
+                    extractor_hash=e_hash
+                )
+
+    def fetch(self, playlist: Playlist) -> List[Video]:
+        return [
+            video
+            for entry, e_hash in self.get_unprocessed_entries(playlist)
+            if (video := self.process_entry(e_hash, entry)[1])
+        ]
+
+
+class Updater:
+    def __init__(self, db_path: str, max_backlog=20, max_fail=5):
+        self.db_path = db_path
+        self.max_items = max_backlog
+        self.max_fail = max_fail
+        self.fetcher = Fetcher(max_backlog)
+
+    def get_new_entries(self, playlist: Playlist) -> List[Tuple[Any, str, Playlist]]:
+        with Database(self.db_path) as database:
+            hashes = frozenset(
+                x.extractor_hash
+                for x in database.list_videos(playlists=[playlist.name])
+            )
+            items = self.fetcher.get_unprocessed_entries(playlist)
+
+            return [
+                (entry, e_hash, playlist)
+                for entry, e_hash in items
+                if e_hash not in hashes
+                   and database.get_extractor_fail_count(e_hash) < self.max_fail
+            ]
+
+    def update(self):
+        num_workers = unpack_optional(os.cpu_count(), lambda: 1) * 4
+
+        with Pool(num_workers) as pool, Database(self.db_path) as database:
+            playlists = database.list_playlists()
+            raw_entries = dict()
+            playlists_mapping = defaultdict(list)
+            full_content = pool.map(self.get_new_entries, playlists)
+            for entry, e_hash, playlist in itertools.chain.from_iterable(full_content):
+                raw_entries[e_hash] = entry
+                playlists_mapping[e_hash].append(playlist)
+
+            results = dict(pool.map(self.fetcher.process_entry, *zip(*raw_entries.items())))
+
+            for key in raw_entries:
+                for playlist in playlists_mapping[key]:
+                    if results[key] is not None:
+                        database.add_videos([results[key]], playlist)
+                    else:
+                        database.increase_extractor_fail_count(key, max_fail=self.max_fail)


### PR DESCRIPTION
The `ytcc subscribe --reverse` option enables a reverse updating of playlists. It first reverses the of the playlist and then cuts the reversed list down to `max_backlog` elements.  Note that this process slows down updating of large playlists that are checked in reverse order.

This change also required a database migration to add the `reverse` column to playlists.