### PR TITLE
Fixed YT subs export parsing, added documentation on how to retrieve subs from YT 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ ytcc subscribe "Jupiter Broadcasting" "https://www.youtube.com/c/JupiterBroadcas
 ytcc subscribe "NCS: House" "https://www.youtube.com/playlist?list=PLRBp0Fe2GpgmsW46rJyudVFlY6IYjFBIK"
 ```
 
-Import subscriptions from Google's takeout data exporting tool ([Learn how to export your youtube subscriptions](doc/yt_export_subs.md).
+Import subscriptions from Google's takeout data exporting tool ([Learn how to export your youtube subscriptions](doc/yt_export_subs.md)).
 ```shell script
-ytcc import ~/Downloads/subscription_manager
+ytcc import subscriptions.json
 ```
 
 Fetch metadata of new videos.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ytcc subscribe "Jupiter Broadcasting" "https://www.youtube.com/c/JupiterBroadcas
 ytcc subscribe "NCS: House" "https://www.youtube.com/playlist?list=PLRBp0Fe2GpgmsW46rJyudVFlY6IYjFBIK"
 ```
 
-Import subscriptions from YouTube's subscription manager export.
+Import subscriptions from Google's takeout data exporting tool ([Learn how to export your youtube subscriptions](doc/yt_export_subs.md).
 ```shell script
 ytcc import ~/Downloads/subscription_manager
 ```

--- a/doc/yt_export_subs.md
+++ b/doc/yt_export_subs.md
@@ -1,6 +1,6 @@
 # Exporting your youtube subscriptions to a JSON file
 
-To do export your youtube subscriptions, follow these steps
+To export your youtube subscriptions, follow these steps
 
 1. After accessing the website, click on **Create new export and Deselect all.**
 2. Scroll down to *Youtube and Youtube Music.*

--- a/doc/yt_export_subs.md
+++ b/doc/yt_export_subs.md
@@ -1,0 +1,12 @@
+# Exporting your youtube subscriptions to a JSON file
+
+To do export your youtube subscriptions, follow these steps
+
+1. After accessing the website, click on **Create new export and Deselect all.**
+2. Scroll down to *Youtube and Youtube Music.*
+3. Then click on **All Youtube Data Included** and again,
+4. click on 'deselect all' and check only the subscriptions entry.
+5. After that, click on **Next**,
+6. click on **Create Export**
+7. decompress the downloaded .zip file (with a tool such as [7-zip](https://www.7-zip.org/)), you should end up with a json file called `subscriptions.json`.
+8. You can now run `ytcc import FILE_PATH` and `ytcc update` (in that order).

--- a/doc/ytcc.1
+++ b/doc/ytcc.1
@@ -3,6 +3,10 @@
 ytcc - a subscription wrapper for youtube-dl playlists
 .SH SYNOPSIS
 ytcc [OPTIONS...] COMMAND [ARGS...]
+
+ytcc import subscriptions.json
+
+ytcc update
 .SH DESCRIPTION
 Ytcc - the (not only) YouTube channel checker.
 
@@ -303,7 +307,9 @@ Show command help and exit.
 
 Import YouTube subscriptions from JSON file.
 
-You can export your YouTube subscriptions at https://www.youtube.com/subscription_manager.
+You can export your YouTube subscriptions at https://takeout.google.com/
+By default, all your *Google* data will be exported. Learn how to only export your youtube
+subscriptions here: https://github.com/TrevCan/ytcc/blob/master/doc/yt_export_subs.md .
 .P
 .B OPTIONS:
 .P

--- a/doc/ytcc.1
+++ b/doc/ytcc.1
@@ -301,7 +301,7 @@ Confirm the action without prompting.
 Show command help and exit.
 .SS import [OPTIONS] FILE
 
-Import YouTube subscriptions from OPML file.
+Import YouTube subscriptions from JSON file.
 
 You can export your YouTube subscriptions at https://www.youtube.com/subscription_manager.
 .P

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -567,9 +567,9 @@ def cleanup(ytcc: core.Ytcc, keep: Optional[int]):
 @click.argument("file", nargs=1, type=click.Path(exists=True, file_okay=True, dir_okay=False))
 @pass_ytcc
 def import_(ytcc: core.Ytcc, file: Path):
-    """Import YouTube subscriptions from OPML file.
+    """Import YouTube subscriptions from JSON file.
 
-    You can export your YouTube subscriptions at https://www.youtube.com/subscription_manager.
+    You can export your YouTube subscriptions from https://takeout.google.com/ . By default, Google Takeout will export all your *Google* data, see this guide: https://github.com/TrevCan/ytcc/blob/master/doc/yt_export_subs.md
     """
     ytcc.import_yt_json(file)
 

--- a/ytcc/cli.py
+++ b/ytcc/cli.py
@@ -571,7 +571,7 @@ def import_(ytcc: core.Ytcc, file: Path):
 
     You can export your YouTube subscriptions at https://www.youtube.com/subscription_manager.
     """
-    ytcc.import_yt_opml(file)
+    ytcc.import_yt_json(file)
 
 
 @cli.command()


### PR DESCRIPTION
Since the removal of the youtube subscriptions export (#94), I decided to figure out how to fix this. After some research, I found out that you can export your youtube subscriptions by using [Google Takeout](https://takeout.google.com). So I replaced the old OPML parser function with one that worked with this JSON file.

- Fixed #94 
- Added documentation on the new way to retrieve your youtube subscriptions as a JSON file (OPML is not an option anymore AFAIK) (README.md, manpage, CLI)
- Added parser to parse JSON data