### PR TITLE
Make ytccf.sh's thumbnails display capable of various backends

### DIFF
--- a/scripts/ytccf.sh
+++ b/scripts/ytccf.sh
@@ -36,66 +36,14 @@ KEY_BINDINGS="
       alt-u: mark last watched video as unwatched
       alt-h: show help"
 
+THUMBNAILS=1
 declare -r -x THUMBNAIL_DIR=$HOME/.cache/ytccf/thumbnails
-declare -r -x UEBERZUG_FIFO="$(mktemp --dry-run --suffix "fzf-$$-ueberzug")"
-declare -r -x PREVIEW_ID="preview"
 
-
-function draw_preview {
-    read TERM_LINES TERM_COLS < <(</dev/tty stty size)
-    X=$((2 * TERM_COLS / 3))
-    Y=3
-    LINES=$((TERM_LINES / 2 - 3))
-    COLUMNS=$((TERM_COLS / 3 ))
-    export TERM_LINES TERM_COLS
-
-    >"${UEBERZUG_FIFO}" declare -A -p cmd=( \
-        [action]=add [identifier]="${PREVIEW_ID}" \
-        [x]="${X}" [y]="${Y}" \
-        [width]="${COLUMNS}" [height]="${LINES}" \
-        [scaler]=fit_contain [scaling_position_x]=0.5 [scaling_position_y]=0.5 \
-        [path]="${@}")
-        # add [synchronously_draw]=True if you want to see each change
-}
-
-function clear_preview {
-    >"${UEBERZUG_FIFO}" declare -A -p cmd=( \
-        [action]=remove [identifier]="${PREVIEW_ID}" \
-    )
-}
-
-function start_ueberzug {
-    mkfifo "${UEBERZUG_FIFO}"
-    <"${UEBERZUG_FIFO}" \
-        ueberzug layer --parser bash --silent &
-    # prevent EOF
-    3>"${UEBERZUG_FIFO}" \
-        exec
-}
-
-function finalise {
-    3>&- \
-        exec
-    &>/dev/null \
-        rm "${UEBERZUG_FIFO}"
-    &>/dev/null \
-        kill "$(jobs -p)"
-}
-
-function fetch_thumbnails() {
-    curl_args=""
-    for line in $(ytcc --output xsv list --attributes id,thumbnail_url $FILTERS); do
-        arr=(${line/,/ })
-        ((${#arr[@]} > 1)) \
-            && ! [[ -e $THUMBNAIL_DIR/${arr[0]} ]] \
-            && curl_args+=" -o $THUMBNAIL_DIR/${arr[0]} ${arr[1]}"
-    done
-    mkdir -p "$THUMBNAIL_DIR"
-    if [[ $curl_args != "" ]]; then
-        echo INFO: Fetching thumbnails
-        curl -L --silent $curl_args
-    fi
-}
+function draw_preview() { :; }
+function clear_preview() { :; } 
+function init_preview() { :; } 
+function finalize_preview() { :; } 
+function fetch_thumbnails() { :; }
 
 function check_cmd() {
     if ! command -v "$1" &> /dev/null; then
@@ -128,6 +76,7 @@ OPTIONS:
   -w, --watched                   Only watched videos are listed.
   -u, --unwatched                 Only unwatched videos are listed.
       --clear-thumbnails          Empty the thumbnail cache.
+      --no-thumbnails             Do not display thumbnails.
   -h, --help                      Show this message and exit.
 
 
@@ -173,6 +122,10 @@ while [[ $# -gt 0 ]]; do
         usage
         exit
         ;;
+    --no-thumbnails)
+        THUMBNAILS=0
+        shift
+        ;;
     --clear-thumbnails)
         rm -r "$THUMBNAIL_DIR" && echo "Successfully cleared thumbnail cache"
         exit
@@ -188,12 +141,88 @@ MAKE_TABLE="$MAKE_TABLE $FILTERS"
 
 check_cmd ytcc
 check_cmd fzf
-check_cmd ueberzug
-check_cmd stty
-check_cmd curl
 
-start_ueberzug
-trap finalise EXIT
+if [[ $THUMBNAILS -eq 1 ]]; then
+    check_cmd curl
+    check_cmd stty
+
+    function fetch_thumbnails() {
+        curl_args=""
+        for line in $(ytcc --output xsv list --attributes id,thumbnail_url $FILTERS); do
+            arr=(${line/,/ })
+            ((${#arr[@]} > 1)) \
+                && ! [[ -e $THUMBNAIL_DIR/${arr[0]} ]] \
+                && curl_args+=" -o $THUMBNAIL_DIR/${arr[0]} ${arr[1]}"
+        done
+        mkdir -p "$THUMBNAIL_DIR"
+        if [[ $curl_args != "" ]]; then
+            echo INFO: Fetching thumbnails
+            curl -L --silent $curl_args
+        fi
+    }
+
+    if [[ $TERM == "xterm-kitty" ]]; then
+        function draw_preview {
+            read TERM_LINES TERM_COLS < <(</dev/tty stty size)
+            X=$((2 * TERM_COLS / 3))
+            Y=3
+            LINES=$((TERM_LINES / 2 - 3))
+            COLUMNS=$((TERM_COLS / 3 ))
+            export TERM_LINES TERM_COLS
+
+            kitty icat --transfer-mode file -z=-1 --place=${COLUMNS}x${LINES}@${X}x${Y} --scale-up "${@}"
+        }
+    else
+        check_cmd ueberzug
+        declare -r -x UEBERZUG_FIFO="$(mktemp --dry-run --suffix "fzf-$$-ueberzug")"
+        declare -r -x PREVIEW_ID="preview"
+
+        function draw_preview {
+            read TERM_LINES TERM_COLS < <(</dev/tty stty size)
+            X=$((2 * TERM_COLS / 3))
+            Y=3
+            LINES=$((TERM_LINES / 2 - 3))
+            COLUMNS=$((TERM_COLS / 3 ))
+            export TERM_LINES TERM_COLS
+
+            >"${UEBERZUG_FIFO}" declare -A -p cmd=( \
+                [action]=add [identifier]="${PREVIEW_ID}" \
+                [x]="${X}" [y]="${Y}" \
+                [width]="${COLUMNS}" [height]="${LINES}" \
+                [scaler]=fit_contain [scaling_position_x]=0.5 [scaling_position_y]=0.5 \
+                [path]="${@}")
+                # add [synchronously_draw]=True if you want to see each change
+        }
+
+        function clear_preview {
+            >"${UEBERZUG_FIFO}" declare -A -p cmd=( \
+                [action]=remove [identifier]="${PREVIEW_ID}" \
+            )
+        }
+
+        function init_preview {
+            mkfifo "${UEBERZUG_FIFO}"
+            <"${UEBERZUG_FIFO}" \
+                ueberzug layer --parser bash --silent &
+            # prevent EOF
+            3>"${UEBERZUG_FIFO}" \
+                exec
+        }
+
+        function finalize_preview {
+            3>&- \
+                exec
+            &>/dev/null \
+                rm "${UEBERZUG_FIFO}"
+            &>/dev/null \
+                kill "$(jobs -p)"
+        }
+    fi
+fi
+
+
+init_preview
+trap finalize_preview EXIT
 fetch_thumbnails
 
 read TERM_LINES TERM_COLS < <(</dev/tty stty size)

--- a/scripts/ytccf.sh
+++ b/scripts/ytccf.sh
@@ -141,10 +141,10 @@ MAKE_TABLE="$MAKE_TABLE $FILTERS"
 
 check_cmd ytcc
 check_cmd fzf
+check_cmd stty
 
 if [[ $THUMBNAILS -eq 1 ]]; then
     check_cmd curl
-    check_cmd stty
 
     function fetch_thumbnails() {
         curl_args=""


### PR DESCRIPTION
- none : some may want no thumbnail display or just can't, so
  --no-thumbnails comes into play.
- ueberzug : by default and can be used in many terminals.
- kitty's icat : autodetected with TERM variable : kitty has its own
  display helper which handles tabs properly.
- other mean may be implemented.