### PR TITLE
Print videos added to the database.

### DIFF
--- a/ytcc/database.py
+++ b/ytcc/database.py
@@ -347,6 +347,14 @@ class Database:
             playlist_id = fetch["id"]
             for video in videos:
                 cursor.execute(insert_video, asdict(video))
+                if isinstance(cursor.lastrowid, int):
+                    logger.info("Added video '%s' of playlist '%s' at ID %d",
+                        video.title,
+                        playlist.name,
+                        cursor.lastrowid
+                    )
+                else:
+                    logger.info("Processed video '%s' of playlist '%s'", video.title, playlist.name)
                 cursor.execute(insert_playlist, (playlist_id, video.url))
 
     @overload

--- a/ytcc/updater.py
+++ b/ytcc/updater.py
@@ -172,7 +172,7 @@ class Fetcher:
             if thumbnails:
                 thumbnail_url = self._get_highest_res_thumbnail(thumbnails).get("url")
 
-            logger.info("Processed video '%s' of playlist '%s'", title, playlist.name)
+            logger.debug("Processed video '%s' of playlist '%s'", title, playlist.name)
 
             return e_hash, Video(
                 url=url,


### PR DESCRIPTION
### What ###

When adding videos to a playlist, print the ID of the added video, as well as the title and name of playlist itself.

### Why ###

To accomodate the use case of invoking `ytcc update` to check for new videos, then `ytcc play` shortly afterwards to play one of the new videos, without needing to invoke `ytcc list` to view the ID.

### How ###

Print the title, playlist, and ID of the video when adding it to the database. The previous processing message is changed to the debug log level