### PR TITLE
Fix Youtube channel with tabs

### DIFF
--- a/ytcc/updater.py
+++ b/ytcc/updater.py
@@ -89,6 +89,27 @@ class Fetcher:
                 )
             else:
                 entries = info.get("entries", [])
+                # 2 options:
+                # - Some channels will directly list videos in the
+                #   `entries` field
+                # - Other channels will have tabs (Videos, Stream, Lives)
+                #   that are represented as sub-playlists in the `entries` field
+                # Note: This is mostly to support channels that enables that
+                # option without having the user to update the subscription.
+                if info.get("webpage_url_basename") not in ["videos",
+                                                            "playlist"]:
+                    logger.debug("Playlist has sub-playlists")
+                    # Entries is a list of info objects for Videos and
+                    # Livestreams
+                    tab_entries = entries
+                    entries = []
+                    for tab in tab_entries:
+                        # Try to find the "videos" tab
+                        # No webpage_url_basename field here :|
+                        # So we need to check that URL ends with /videos
+                        if tab.get("webpage_url").endswith("/videos"):
+                            entries = tab.get("entries", [])
+                            break
                 if playlist.reverse:
                     entries = reversed(list(entries))
                 for entry in take(self.max_items, entries):


### PR DESCRIPTION
Youtube channel can enable additional features (eg. Shorts) which results in the channel having corresponding tabs.

Updating such a channel was broken as the object returned by YoutubeDL.extract_info will contains a "sub playlist". Fix the issue by checking if we have sub playlists and finding the one that is used for videos.

Note: this means we don't support any types other than Videos for now.

Fixes #113